### PR TITLE
Add llms.txt as auto-generating Jekyll Liquid template

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -6,7 +6,7 @@ permalink: /llms.txt
 
 > {{ site.description }} {{ site.author_bio }}
 
-This is a personal tech blog covering Azure IoT, Azure Digital Twins, AI/ML, and software engineering. Posts range from hands-on tutorials and project walkthroughs to opinion pieces on LLMs and AI agents.
+This is a personal tech blog covering Microsoft Foundry, Agent Service, Agentic AI, genAI, and software engineering. Posts range from hands-on tutorials and project walkthroughs to opinion pieces on LLMs and AI agents.
 
 ## Blog Posts
 {% for post in site.posts %}

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,20 @@
+---
+layout: null
+permalink: /llms.txt
+---
+# {{ site.title }}
+
+> {{ site.description }} {{ site.author_bio }}
+
+This is a personal tech blog covering Azure IoT, Azure Digital Twins, AI/ML, and software engineering. Posts range from hands-on tutorials and project walkthroughs to opinion pieces on LLMs and AI agents.
+
+## Blog Posts
+{% for post in site.posts %}
+- [{{ post.title }}]({% if post.external_url %}{{ post.external_url }}{% else %}{{ site.url }}{{ post.url }}{% endif %}){% if post.description %}: {{ post.description }}{% endif %}
+{%- endfor %}
+
+## Links
+
+- [GitHub]({{ site.social.github }})
+- [LinkedIn]({{ site.social.linkedin }})
+- [Substack]({{ site.social.substack }})


### PR DESCRIPTION
## Summary

Adds a `/llms.txt` endpoint following the [llmstxt.org](https://llmstxt.org) specification, making the blog's content more accessible and discoverable by Large Language Models.

## Implementation

The file is a **Jekyll Liquid template** that auto-generates the post list at build time, so it stays current as new posts are added — no manual maintenance required.

### What's included in the output:
- **H1** — Blog title (from `_config.yml`)
- **Blockquote** — Blog description + author bio
- **Intro paragraph** — Summary of blog themes
- **Blog Posts** — All posts with titles, URLs, and descriptions (newest first)
- **Links** — GitHub, LinkedIn, Substack

### Design decisions:
- **Liquid template over static file** — stays up-to-date automatically as posts are added
- **Liquid template over external tooling** — zero new dependencies; idiomatic for Jekyll/GitHub Pages
- **External/redirect posts** (Substack articles) correctly link to their `external_url`
- **No `llms-full.txt`** — not part of the llmstxt.org spec (that's a project-specific convention from FastHTML)
- **No `_config.yml` changes needed** — `.txt` files are served by Jekyll by default

### Verified:
- `bundle exec jekyll build` succeeds
- Output at `_site/llms.txt` is valid markdown following the spec format
- `bundle exec jekyll serve` serves the file correctly at `/llms.txt`
