### PR TITLE
Refresh sessionize data (2026-05-21)

### DIFF
--- a/_data/sessionize.yml
+++ b/_data/sessionize.yml
@@ -1,5 +1,5 @@
 # Snapshot of https://sessionize.com/api/speaker/json/32v3odtbr8
-# Refreshed 2026-05-05
+# Refreshed 2026-05-21
 
 events:
   - id: 22189


### PR DESCRIPTION
Refreshes `_data/sessionize.yml` by re-running the `scripts/fetch-sessionize.sh` script against the live Sessionize speaker API. The only change is the "Refreshed" date stamp updating to today's date -- the event and session data was already current.